### PR TITLE
알림 중복 전송 방지 로직 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
+
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/couponmoa/backend/couponmoanotification/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/couponmoa/backend/couponmoanotification/domain/notification/service/NotificationService.java
@@ -2,18 +2,20 @@ package com.couponmoa.backend.couponmoanotification.domain.notification.service;
 
 import com.couponmoa.backend.couponmoanotification.domain.email.dto.EmailDto;
 import com.couponmoa.backend.couponmoanotification.domain.email.service.EmailSenderService;
+import com.couponmoa.backend.couponmoanotification.domain.notification.entity.Notification;
+import com.couponmoa.backend.couponmoanotification.domain.notification.repository.NotificationRepository;
 import com.couponmoa.backend.couponmoanotification.domain.sqs.dto.CouponCreateMessage;
 import com.couponmoa.backend.couponmoanotification.domain.sqs.dto.CouponExpireMessage;
 import com.couponmoa.backend.couponmoanotification.domain.sqs.dto.CouponIssueMessage;
-import com.couponmoa.backend.couponmoanotification.domain.notification.entity.Notification;
-import com.couponmoa.backend.couponmoanotification.domain.notification.repository.NotificationRepository;
 import com.couponmoa.backend.couponmoanotification.domain.sqs.dto.CouponUseMessage;
 import com.couponmoa.backend.couponmoanotification.domain.sse.dto.SseDto;
 import com.couponmoa.backend.couponmoanotification.domain.sse.service.SseEmitterService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 
 @Service
@@ -23,14 +25,15 @@ public class NotificationService {
     private final NotificationRepository notificationRepository;
     private final SseEmitterService sseEmitterService;
     private final EmailSenderService emailSenderService;
+    private final RedisTemplate<String, String> redisTemplate;
 
-    public void handleCouponCreateMessage(CouponCreateMessage message) {
-        EmailDto emailDto = EmailDto.from(message);
-        emailSenderService.send(emailDto);
-    }
+    private static final Duration TTL = Duration.ofHours(6);
 
     @Transactional
     public void handleCouponIssueMessage(CouponIssueMessage message) {
+        String key = "coupon-issue:" + message.getCouponName() + ":" + message.getUserCouponId();
+        if (!acquireNotificationLock(key)) return;
+
         Notification issueNotification = Notification.forIssue(message.getUserCouponId());
         notificationRepository.save(issueNotification);
 
@@ -50,6 +53,10 @@ public class NotificationService {
 
     @Transactional
     public void handleCouponExpireMessage(CouponExpireMessage message) {
+        // 멱등성 보장
+        String key = "expire-coupon:" + message.getCouponName() + ":" + message.getExpiryDate().toLocalDate();
+        if (!acquireNotificationLock(key)) return;
+
         try {
             EmailDto emailDto = EmailDto.from(message);
             emailSenderService.send(emailDto);
@@ -59,6 +66,11 @@ public class NotificationService {
         }
     }
 
+    public void handleCouponCreateMessage(CouponCreateMessage message) {
+        EmailDto emailDto = EmailDto.from(message);
+        emailSenderService.send(emailDto);
+    }
+
     @Transactional
     public void handleCouponUseMessage(CouponUseMessage message) {
         notificationRepository.deleteExpireNotificationByUserCouponId(message.getUserCouponId());
@@ -66,5 +78,10 @@ public class NotificationService {
 
     private boolean shouldCreateExpireNotification(LocalDateTime expiryDate) {
         return expiryDate.isAfter(LocalDateTime.now().plusDays(1));
+    }
+
+    private boolean acquireNotificationLock(String key) {
+        Boolean result = redisTemplate.opsForValue().setIfAbsent(key, "sent", TTL);
+        return Boolean.TRUE.equals(result);
     }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -20,3 +20,8 @@ spring:
     aws:
       region:
         static: ${AWS_REGION}
+
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: 6379

--- a/src/test/java/com/couponmoa/backend/couponmoanotification/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/couponmoa/backend/couponmoanotification/domain/notification/service/NotificationServiceTest.java
@@ -18,6 +18,8 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -38,6 +40,10 @@ class NotificationServiceTest {
     private SseEmitterService sseEmitterService;
     @Mock
     private EmailSenderService emailSenderService;
+    @Mock
+    private StringRedisTemplate redisTemplate;
+    @Mock
+    private ValueOperations<String, String> valueOperations;
     @InjectMocks
     private NotificationService notificationService;
 
@@ -75,7 +81,8 @@ class NotificationServiceTest {
         @Order(1)
         void 쿠폰_발급_알림_쿠폰_발급_알림만_저장_성공() {
             CouponIssueMessage message = new CouponIssueMessage(1L, 1L, "couponName", LocalDateTime.now());
-
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.setIfAbsent(anyString(), anyString(), any())).thenReturn(true);
             notificationService.handleCouponIssueMessage(message);
 
             verify(notificationRepository, times(1)).save(any(Notification.class));
@@ -84,6 +91,8 @@ class NotificationServiceTest {
         @Test
         @Order(2)
         void 쿠폰_발급_알림_쿠폰_만료_알림도_저장_성공() {
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.setIfAbsent(anyString(), anyString(), any())).thenReturn(true);
             notificationService.handleCouponIssueMessage(message);
 
             verify(notificationRepository, times(2)).save(any(Notification.class));
@@ -92,6 +101,8 @@ class NotificationServiceTest {
         @Test
         @Order(3)
         void 쿠폰_발급_알림_sse_전송_실패() {
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.setIfAbsent(anyString(), anyString(), any())).thenReturn(true);
             doThrow(new RuntimeException()).when(sseEmitterService).send(any(SseDto.class));
 
             notificationService.handleCouponIssueMessage(message);
@@ -104,11 +115,25 @@ class NotificationServiceTest {
         @Test
         @Order(4)
         void 쿠폰_발급_알림_sse_전송_성공() {
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.setIfAbsent(anyString(), anyString(), any())).thenReturn(true);
             notificationService.handleCouponIssueMessage(message);
 
             verify(notificationRepository, atLeastOnce()).save(notificationCaptor.capture());
             Notification issueNotification = notificationCaptor.getAllValues().get(0);
             assertEquals(NotificationStatus.SENT, issueNotification.getStatus());
+        }
+
+        @Test
+        @Order(5)
+        void 쿠폰_발급_알림_멱등성_체크_락_획득_실패_시_알림_실패() {
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.setIfAbsent(anyString(), anyString(), any())).thenReturn(false);
+
+            notificationService.handleCouponIssueMessage(message);
+
+            verify(notificationRepository, never()).save(any());
+            verify(sseEmitterService, never()).send(any());
         }
     }
 
@@ -121,6 +146,8 @@ class NotificationServiceTest {
         @Test
         @Order(1)
         void 쿠폰_만료_알림_이메일_전송_실패() {
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.setIfAbsent(anyString(), anyString(), any())).thenReturn(true);
             doThrow(new IllegalStateException()).when(emailSenderService).send(any(EmailDto.class));
 
             notificationService.handleCouponExpireMessage(message);
@@ -132,10 +159,23 @@ class NotificationServiceTest {
         @Test
         @Order(2)
         void 쿠폰_만료_알림_이메일_전송_성공() {
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.setIfAbsent(anyString(), anyString(), any())).thenReturn(true);
             notificationService.handleCouponExpireMessage(message);
 
             verify(notificationRepository, never()).markExpireNotificationAsFailed(anyList());
             verify(notificationRepository, times(1)).markExpireNotificationAsSent(anyList());
+        }
+
+        @Test
+        @Order(3)
+        void 쿠폰_만료_알림_멱등성_체크_락_획득_실패_시_알림_실패() {
+            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+            when(valueOperations.setIfAbsent(anyString(), anyString(), any())).thenReturn(false);
+
+            notificationService.handleCouponExpireMessage(message);
+
+            verify(notificationRepository, never()).markExpireNotificationAsFailed(anyList());
         }
     }
 


### PR DESCRIPTION
📌 개요 (Overview)
알림 중복 전송 방지를 위한 멱등성 보장 기능 도입
오토스케일링 환경에서도 알림이 한 번만 전송되도록 처리

✅ 작업 내용 (Tasks)
redis 의존성 주입
setIfAbsent를 사용한 상태 캐싱 로직 추가
TTL 설정해서 일정 시간 지나면 자동 삭제 설정

🎯 결과 (Result)
알림 중복 전송 방지