### PR TITLE
알림 중복 전송 방지 lua script 활용

### DIFF
--- a/src/main/java/com/couponmoa/backend/couponmoanotification/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/couponmoa/backend/couponmoanotification/domain/notification/service/NotificationService.java
@@ -12,11 +12,13 @@ import com.couponmoa.backend.couponmoanotification.domain.sse.dto.SseDto;
 import com.couponmoa.backend.couponmoanotification.domain.sse.service.SseEmitterService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.Collections;
 
 @Service
 @RequiredArgsConstructor
@@ -81,7 +83,24 @@ public class NotificationService {
     }
 
     private boolean acquireNotificationLock(String key) {
-        Boolean result = redisTemplate.opsForValue().setIfAbsent(key, "sent", TTL);
-        return Boolean.TRUE.equals(result);
+        String script =
+                "if redis.call('SETNX', KEYS[1], ARGV[1]) == 1 then " +
+                        "   redis.call('EXPIRE', KEYS[1], tonumber(ARGV[2])) " +
+                        "   return 1 " +
+                        "else " +
+                        "   return 0 " +
+                        "end";
+
+        DefaultRedisScript<Long> redisScript = new DefaultRedisScript<>();
+        redisScript.setScriptText(script);
+        redisScript.setResultType(Long.class);
+
+        Long result = redisTemplate.execute(
+                redisScript,
+                Collections.singletonList(key),
+                "sent", String.valueOf(TTL.getSeconds())
+        );
+
+        return result != null && result == 1;
     }
 }

--- a/src/test/java/com/couponmoa/backend/couponmoanotification/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/couponmoa/backend/couponmoanotification/domain/notification/service/NotificationServiceTest.java
@@ -20,6 +20,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -81,8 +82,7 @@ class NotificationServiceTest {
         @Order(1)
         void 쿠폰_발급_알림_쿠폰_발급_알림만_저장_성공() {
             CouponIssueMessage message = new CouponIssueMessage(1L, 1L, "couponName", LocalDateTime.now());
-            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-            when(valueOperations.setIfAbsent(anyString(), anyString(), any())).thenReturn(true);
+            when(redisTemplate.execute(any(DefaultRedisScript.class), anyList(), any(), any())).thenReturn(1L);
             notificationService.handleCouponIssueMessage(message);
 
             verify(notificationRepository, times(1)).save(any(Notification.class));
@@ -91,8 +91,7 @@ class NotificationServiceTest {
         @Test
         @Order(2)
         void 쿠폰_발급_알림_쿠폰_만료_알림도_저장_성공() {
-            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-            when(valueOperations.setIfAbsent(anyString(), anyString(), any())).thenReturn(true);
+            when(redisTemplate.execute(any(DefaultRedisScript.class), anyList(), any(), any())).thenReturn(1L);
             notificationService.handleCouponIssueMessage(message);
 
             verify(notificationRepository, times(2)).save(any(Notification.class));
@@ -101,8 +100,7 @@ class NotificationServiceTest {
         @Test
         @Order(3)
         void 쿠폰_발급_알림_sse_전송_실패() {
-            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-            when(valueOperations.setIfAbsent(anyString(), anyString(), any())).thenReturn(true);
+            when(redisTemplate.execute(any(DefaultRedisScript.class), anyList(), any(), any())).thenReturn(1L);
             doThrow(new RuntimeException()).when(sseEmitterService).send(any(SseDto.class));
 
             notificationService.handleCouponIssueMessage(message);
@@ -115,8 +113,7 @@ class NotificationServiceTest {
         @Test
         @Order(4)
         void 쿠폰_발급_알림_sse_전송_성공() {
-            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-            when(valueOperations.setIfAbsent(anyString(), anyString(), any())).thenReturn(true);
+            when(redisTemplate.execute(any(DefaultRedisScript.class), anyList(), any(), any())).thenReturn(1L);
             notificationService.handleCouponIssueMessage(message);
 
             verify(notificationRepository, atLeastOnce()).save(notificationCaptor.capture());
@@ -127,8 +124,7 @@ class NotificationServiceTest {
         @Test
         @Order(5)
         void 쿠폰_발급_알림_멱등성_체크_락_획득_실패_시_알림_실패() {
-            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-            when(valueOperations.setIfAbsent(anyString(), anyString(), any())).thenReturn(false);
+            when(redisTemplate.execute(any(DefaultRedisScript.class), anyList(), any(), any())).thenReturn(0L);
 
             notificationService.handleCouponIssueMessage(message);
 
@@ -146,8 +142,8 @@ class NotificationServiceTest {
         @Test
         @Order(1)
         void 쿠폰_만료_알림_이메일_전송_실패() {
-            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-            when(valueOperations.setIfAbsent(anyString(), anyString(), any())).thenReturn(true);
+            when(redisTemplate.execute(any(DefaultRedisScript.class), anyList(), any(), any())).thenReturn(1L);
+
             doThrow(new IllegalStateException()).when(emailSenderService).send(any(EmailDto.class));
 
             notificationService.handleCouponExpireMessage(message);
@@ -159,8 +155,8 @@ class NotificationServiceTest {
         @Test
         @Order(2)
         void 쿠폰_만료_알림_이메일_전송_성공() {
-            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-            when(valueOperations.setIfAbsent(anyString(), anyString(), any())).thenReturn(true);
+            when(redisTemplate.execute(any(DefaultRedisScript.class), anyList(), any(), any())).thenReturn(1L);
+
             notificationService.handleCouponExpireMessage(message);
 
             verify(notificationRepository, never()).markExpireNotificationAsFailed(anyList());
@@ -170,8 +166,7 @@ class NotificationServiceTest {
         @Test
         @Order(3)
         void 쿠폰_만료_알림_멱등성_체크_락_획득_실패_시_알림_실패() {
-            when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-            when(valueOperations.setIfAbsent(anyString(), anyString(), any())).thenReturn(false);
+            when(redisTemplate.execute(any(DefaultRedisScript.class), anyList(), any(), any())).thenReturn(0L);
 
             notificationService.handleCouponExpireMessage(message);
 


### PR DESCRIPTION
📌 개요 (Overview)
알림 중복 전송 방지를 위한 멱등성 보장 기능 도입
오토스케일링 환경에서도 알림이 한 번만 전송되도록 처리

✅ 작업 내용 (Tasks)
redis setIfAbsent를 통해 중복 방지하던 코드를 lua script로 변경
테스트 코드도 함께 수정

🎯 결과 (Result)
알림 중복 전송 방지